### PR TITLE
Remove version from show-plugin btest in prep for 2.7

### DIFF
--- a/tests/fix_sbe/show-plugin.bro
+++ b/tests/fix_sbe/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN RLABS::FIX_SBE >output
+# @TEST-EXEC: bro -NN RLABS::FIX_SBE |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION

Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.